### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_disabled.yml
+++ b/.github/workflows/docker_disabled.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: actions/checkout@master
       - run:  bash exp.sh
-      - uses: elgohr/Publish-Docker-Github-Action@master
+      - uses: elgohr/Publish-Docker-Github-Action@v5
 
         with:
 


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore